### PR TITLE
For topics improvements branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Read events from Pyroclast Topics.
 ;;
 ;; Poll the topic using the consumer instance map returned from topic-subscribe.
 ;; Note that JSON records are returned.
-@(client/topic-consumer-poll! config consumer-instance-map)
+@(client/topic-consumer-poll! consumer-instance-map)
 ;; => [{"value" {"event-type" "page-visit" "page" "/home" "timestamp" 1495072835000}}
 ;;     {"value" {"event-type" "page-visit" "page" "/home" "timestamp" 1495072835032}}]
 
@@ -66,14 +66,14 @@ Read events from Pyroclast Topics.
 
 ;; Subsequent topic-consumer-poll!'s return nothing, since we've already consumed up to
 ;; the largest offset on our consumer instance.
-@(client/topic-consumer-poll! config consumer-instance-map)
+@(client/topic-consumer-poll! consumer-instance-map)
 ;; => []
 
 ;; Reset back to the beginning with
-(client/topic-consumer-seek-beginning config consumer-instance-map) ;; => true
+(client/topic-consumer-seek-beginning consumer-instance-map) ;; => true
 
 ;; Polling returns results again.
-@(client/topic-consumer-poll! config consumer-instance-map)
+@(client/topic-consumer-poll! consumer-instance-map)
 ;; => [{"value" {"event-type" "page-visit" "page" "/home" "timestamp" 1495072835000}}
 ;;     {"value" {"event-type" "page-visit" "page" "/home" "timestamp" 1495072835032}}]
 
@@ -82,11 +82,12 @@ Read events from Pyroclast Topics.
 ;; Commit the highest offset the consumer has read from, so consumer
 ;; instances on the consumer group "my-consumer-group" will start
 ;; reading after this commit.
-(client/topic-consumer-commit-offsets config consumer-instance-map)
+(client/topic-consumer-commit-offsets consumer-instance-map)
 ;; => true
 
+;; New consumer instances start reading after the last commit.
 (def new-consumer-instance (topic-subscribe config "my-consumer-group"))
-@(client/topic-consumer-poll! config new-consumer-instance)
+@(client/topic-consumer-poll! new-consumer-instance)
 ;; => []
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Read events from Pyroclast Topics.
    :pyroclast.api/region "us-west-2"})
 
 ;; Subscribe to a topic, registering a new Consumer Group
-(def consumer-instance-map @(client/topic-subscribe config "my-consumer-group"))
+(def consumer-instance-map (client/topic-subscribe config "my-consumer-group"))
 ;; => {:group-id my-consumer-group, :consumer-instance-id 4e5f319b-4f97-4556-b0b6-aa9a9ff087f3}
 ;;
 ;; Poll the topic using the consumer instance map returned from topic-subscribe.
@@ -85,7 +85,7 @@ Read events from Pyroclast Topics.
 (client/topic-consumer-commit-offsets config consumer-instance-map)
 ;; => true
 
-(def new-consumer-instance @(topic-subscribe config "my-consumer-group"))
+(def new-consumer-instance (topic-subscribe config "my-consumer-group"))
 @(client/topic-consumer-poll! config new-consumer-instance)
 ;; => []
 

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [cheshire "5.7.1"]
-                 [clj-http "3.5.0"]]
+                 [clj-http "3.5.0"]
+                 [manifold "0.1.6"]]
   :test-selectors {:roaming :roaming
                    :topic :topic})

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -3,4 +3,11 @@
          :write-api-key ""
          :topic-id ""
          :endpoint ""
-         :format :json}}
+         :format :json}
+ :client-config {:pyroclast.topic/write-key "d8b5869d-69a9-4935-9a35-cd0f67379124"
+                 :pyroclast.topic/read-key "db621c74-0d8d-41ed-b4e2-d4279e8b46f8"
+                 :pyroclast.topic/id "topic-35e284dc-8b0c-4866-b33b-8895c25ff7f6"
+                 :pyroclast.deployment/id "59e75abd-5d68-43a2-aef3-eb7c2f61dafa"
+                 :pyroclast.deployment/read-key "3a2b87ae-1042-4a24-bc4e-b56e1ca50170"
+                 :pyroclast.api/endpoint "http://localhost:10556"
+                 :pyroclast.api/region "us-west-2"}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -7,7 +7,9 @@
  :topic-client-config {:pyroclast.topic/write-key "b2f1ef07-3273-48d8-8226-e0ad057605e9"
                        :pyroclast.topic/id "topic-6516b60c-622d-42c7-8b1d-80e6d8bf1c1e"
                        :pyroclast.topic/read-key "56dd47d0-8c42-4075-99b8-7cf272c8598b"
+                       ;:pyroclast.api/region "us-west-2"
                        :pyroclast.api/endpoint "http://localhost:10556"}
  :aggregate-client-config {:pyroclast.deployment/id "59e918b9-ce65-4e77-a3ed-31c23b0bff10",
                            :pyroclast.deployment/read-key "d5e6f1e3-1751-4934-aee2-3f1bfafe23a2"
+                           ;:pyroclast.api/region "us-west-2"
                            :pyroclast.api/endpoint "http://localhost:10555"}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -4,10 +4,10 @@
          :topic-id ""
          :endpoint ""
          :format :json}
- :client-config {:pyroclast.topic/write-key "d8b5869d-69a9-4935-9a35-cd0f67379124"
-                 :pyroclast.topic/read-key "db621c74-0d8d-41ed-b4e2-d4279e8b46f8"
-                 :pyroclast.topic/id "topic-35e284dc-8b0c-4866-b33b-8895c25ff7f6"
-                 :pyroclast.deployment/id "59e75abd-5d68-43a2-aef3-eb7c2f61dafa"
-                 :pyroclast.deployment/read-key "3a2b87ae-1042-4a24-bc4e-b56e1ca50170"
-                 :pyroclast.api/endpoint "http://localhost:10556"
-                 :pyroclast.api/region "us-west-2"}}
+ :topic-client-config {:pyroclast.topic/write-key "b2f1ef07-3273-48d8-8226-e0ad057605e9"
+                       :pyroclast.topic/id "topic-6516b60c-622d-42c7-8b1d-80e6d8bf1c1e"
+                       :pyroclast.topic/read-key "56dd47d0-8c42-4075-99b8-7cf272c8598b"
+                       :pyroclast.api/endpoint "http://localhost:10556"}
+ :aggregate-client-config {:pyroclast.deployment/id "59e918b9-ce65-4e77-a3ed-31c23b0bff10",
+                           :pyroclast.deployment/read-key "d5e6f1e3-1751-4934-aee2-3f1bfafe23a2"
+                           :pyroclast.api/endpoint "http://localhost:10555"}}

--- a/src/pyroclast_clojure/v1/client.clj
+++ b/src/pyroclast_clojure/v1/client.clj
@@ -54,8 +54,8 @@
     (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
     (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
     (= status 500) (md/error! deferred (ex-info (str "Server error: " body) {}))
-    :else (md/error! deferred (ex-info (format "Unknown status %s. Open an issue on this repository if you're seeing this status." status) 
-                                       {})))) 
+    :else (md/error! deferred (ex-info (format "Unknown status %s. Open an issue on this repository if you're seeing this status." status)
+                                       {}))))
 
 (defn topic-send-event!
   "Send a single event to a Pyroclast topic.
@@ -86,7 +86,7 @@
      (run! validate-event! events)
      (http/post (topic-bulk-produce-url config)
                 {:async? true
-                 :throw-exceptions true
+                 :throw-exceptions false
                  :headers {"Content-type" "application/json"
                            "Authorization" write-key}
                  :body (json/generate-string events)}
@@ -107,8 +107,8 @@
 
   Returns a topic instance map."
   ([config consumer-group-name] (topic-subscribe config consumer-group-name {}))
-  ([{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config} 
-    consumer-group-name 
+  ([{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+    consumer-group-name
     {:keys [auto-offset-reset partitions]
      :or {auto-offset-reset :earliest partitions :all}}]
    (when (not (re-matches #"[a-zA-Z0-9-_]+" consumer-group-name))
@@ -117,7 +117,7 @@
    (let [prom (md/deferred)]
      (http/post (topic-subscribe-url config consumer-group-name)
                 {:async? true
-                 :throw-exceptions true
+                 :throw-exceptions false
                  :headers {"Content-type" "application/json"
                            "Authorization" read-key}
                  :body (json/generate-string {"auto.offset.reset" auto-offset-reset "partitions" partitions})}
@@ -139,7 +139,7 @@
   (let [promise (md/deferred)]
     (http/post (topic-poll-url config group-id consumer-instance-id)
                {:async? true
-                :throw-exceptions true
+                :throw-exceptions false
                 :headers {"Content-type" "application/json"
                           "Authorization" read-key}}
                (fn [{:keys [status body] :as resp}]
@@ -159,7 +159,7 @@
                {:async? true
                 :headers {"Content-type" "application/json"
                           "Authorization" read-key}
-                :throw-exceptions true
+                :throw-exceptions false
                 :as :text}
                (fn [{:keys [status] :as resp}]
                  (if (= 200 status)
@@ -179,7 +179,7 @@
                {:async? true
                 :headers {"Content-type" "application/json"
                           "Authorization" read-key}
-                :throw-exceptions true
+                :throw-exceptions false
                 :as :text}
                (fn [{:keys [status] :as resp}]
                  (if (= 200 status)
@@ -223,7 +223,7 @@
   (let [promise (md/deferred)]
     (http/post (topic-seek-url config group-id consumer-instance-id)
                {:async? true
-                :throw-exceptions true
+                :throw-exceptions false
                 :headers {"Content-type" "application/json"
                           "Authorization" read-key}
 
@@ -250,7 +250,7 @@
         query (assoc query :datetime-format :iso-8601)]
     (http/get (deployment-aggregate-url config aggregate-name)
               {:async? true
-               :throw-exceptions true
+               :throw-exceptions false
                :headers {"Content-type" "application/json"
                          "Authorization" read-key}
                :body (json/generate-string query)}
@@ -269,7 +269,7 @@
   (let [promise (md/deferred)]
     (http/get (deployment-aggregates-url config)
               {:async? true
-               :throw-exceptions true
+               :throw-exceptions false
                :headers {"Content-type" "application/json"
                          "Authorization" read-key}}
               (fn [{:keys [status body] :as resp}]

--- a/src/pyroclast_clojure/v1/client.clj
+++ b/src/pyroclast_clojure/v1/client.clj
@@ -125,8 +125,7 @@
                   (if (= 201 status)
                     (md/success! prom (json/parse-string body true))
                     (common-response prom resp)))
-                (fn [resp]
-                  (common-response promise (ex-data resp))))
+                (partial md/error! prom))
      (deref prom))))
 
 (defn topic-consumer-poll!
@@ -147,8 +146,7 @@
                  (if (= 200 status)
                    (md/success! promise (vec (json/parse-string body)))
                    (common-response promise resp)))
-               (fn [resp]
-                 (common-response promise (ex-data resp))))
+               (partial md/error! promise))
     promise))
 
 (defn topic-consumer-commit-offsets
@@ -167,8 +165,7 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (fn [resp]
-                 (common-response promise (ex-data resp))))
+               (partial md/error! promise))
     ;; Probably want this to be synchronous to avoid late commits.
     @promise))
 
@@ -188,8 +185,7 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (fn [resp]
-                 (common-response promise (ex-data resp))))
+               (partial md/error! promise))
     @promise))
 
 (defn topic-consumer-seek-beginning
@@ -236,8 +232,7 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (fn [resp]
-                 (common-response promise (ex-data resp))))
+               (partial md/error! promise))
     @promise))
 
 (defn deployment-fetch-aggregate
@@ -263,8 +258,7 @@
                 (if (= 200 status)
                   (md/success! promise (json/parse-string body))
                   (common-response promise resp)))
-              (fn [resp]
-                (common-response promise (ex-data resp))))
+              (partial md/error! promise))
     promise))
 
 (defn deployment-fetch-aggregates
@@ -282,8 +276,7 @@
                 (if (= 200 status)
                   (md/success! promise (json/parse-string body))
                   (common-response promise resp)))
-              (fn [resp]
-                (common-response promise (ex-data resp))))
+              (partial md/error! promise))
     promise))
 
 ;; Unimplemented

--- a/src/pyroclast_clojure/v1/client.clj
+++ b/src/pyroclast_clojure/v1/client.clj
@@ -1,220 +1,325 @@
 (ns pyroclast-clojure.v1.client
-  (:require [clojure.string :refer [join]]
-            [clojure.tools.logging :as log]
-            [clj-http.client :as client]
-            [cheshire.core :refer [generate-string parse-string]]))
+  (:require [clj-http.client :as http]
+            [cheshire.core :as json]
+            [manifold.deferred :as md]))
 
 (def default-region "us-west-2")
 
-(def unknown-message "Unknown problem. Open an issue on this repository if you're seeing this status.")
-
-(defmulti format-payload
-  (fn [fmt payload]
-    fmt))
-
-(defmethod format-payload :json
-  [fmt payload]
-  (generate-string payload))
-
-(defmethod format-payload :none
-  [fmt payload]
-  payload)
-
-(defmulti content-type
-  (fn [fmt] fmt))
-
-(defmethod content-type :json
-  [fmt] "application/json")
-
-(defmethod content-type :none
-  [fmt] "text/plain")
-
-(defn process-topic-response [{:keys [status body] :as response}]
-  (cond (= status 200)
-        (parse-string body true)
-
-        (= status 400)
-        {:created false :reason "Event data was malformed."}
-
-        (= status 401)
-        {:created false :reason "API key unauthorized to perform this action."}
-
-        :else
-        {:created false :reason unknown-message :response response}))
-
-(defn base-url [{:keys [region endpoint] :or {region default-region} :as config}]
+;;;; URLs
+(defn- base-url [{:keys [pyroclast.api/region pyroclast.api/endpoint] :or {region default-region} :as config}]
   (if endpoint
     endpoint
     (str (format "https://api.%s.pyroclast.io" region))))
 
-(defn process-exception [e]
-  (log/warn e "This function should never be invoked. Open an issue on this library if you see this."))
+(defn topic-produce-url [{:keys [pyroclast.topic/id] :as config}]
+  (format "%s/v1/topics/%s/produce" (base-url config) id))
 
-(defn validate-event! [event]
+(defn topic-bulk-produce-url [{:keys [pyroclast.topic/id] :as config}]
+  (format "%s/v1/topics/%s/bulk-produce" (base-url config) id))
+
+(defn topic-subscribe-url [{:keys [pyroclast.topic/id] :as config} consumer-group-name]
+  (format "%s/v1/topics/%s/consumers/%s/subscribe" (base-url config) id consumer-group-name))
+
+(defn topic-poll-url [{:keys [pyroclast.topic/id] :as config} consumer-group-name consumer-instance-id]
+  (format "%s/v1/topics/%s/consumers/%s/instances/%s/poll" (base-url config)
+          id consumer-group-name consumer-instance-id))
+
+(defn topic-commit-url [{:keys [pyroclast.topic/id] :as config} consumer-group-name consumer-instance-id]
+  (format "%s/v1/topics/%s/consumers/%s/instances/%s/commit" (base-url config)
+          id consumer-group-name consumer-instance-id))
+
+(defn topic-seek-url
+  ([{:keys [pyroclast.topic/id] :as config} consumer-group-name consumer-instance-id]
+   (topic-seek-url config consumer-group-name consumer-instance-id nil))
+  ([{:keys [pyroclast.topic/id] :as config} consumer-group-name consumer-instance-id direction]
+   (if direction
+     (format "%s/v1/topics/%s/consumers/%s/instances/%s/seek/%s" (base-url config)
+             id consumer-group-name consumer-instance-id direction)
+     (format "%s/v1/topics/%s/consumers/%s/instances/%s/seek" (base-url config)
+             id consumer-group-name consumer-instance-id))))
+
+(defn deployment-aggregates-url
+  [{:keys [pyroclast.deployment/id] :as config}]
+  (format "%s/v1/deployments/%s/aggregates" (base-url config) id))
+
+(defn deployment-aggregate-url
+  [{:keys [pyroclast.deployment/id] :as config} aggregate-name]
+  (format "%s/v1/deployments/%s/aggregates/%s" (base-url config) id aggregate-name))
+
+;;; Produce
+(defn- validate-event! [event]
   (when-not (contains? event :value)
     (throw (ex-info "Event requires :value key" {:event event}))))
 
-(defn send-event! [{:keys [write-api-key topic-id] :as config} event]
-  (validate-event! event)
-  (let [response
-        (client/post (format "%s/v1/topics/%s/produce" (base-url config) topic-id)
-                     {:headers {"Authorization" write-api-key
-                                "Content-type" (content-type (:format config))}
-                      :body (format-payload (:format config) event)
-                      :accept :json})]
-    (process-topic-response response)))
+(defn- check-topic-produce-response
+  "Handles API and HTTP Client errors, bubbling both back up the promise chain."
+  [deferred {:keys [status] :as response}]
+  (cond (= status 200) (md/success! deferred true)
+        (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
+        (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
+        :else (md/error! deferred (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {}))))
 
-(defn send-events! [{:keys [write-api-key topic-id] :as config} events]
-  (run! validate-event! events)
-  (let [response
-        (client/post (format "%s/v1/topics/%s/bulk-produce" (base-url config) topic-id)
-                     {:headers {"Authorization" write-api-key
-                                "Content-type" (content-type (:format config))}
-                      :body (format-payload (:format config) events)
-                      :accept :json})]
-    (process-topic-response response)))
+(defn topic-send-event!
+  "Send a single event to a Pyroclast topic.
+  Event must be of the form {:value ...}.
+  Returns a dereffable deferred."
+  ([{:keys [pyroclast.topic/write-key pyroclast.topic/id] :as config} event]
+   (let [response (md/deferred)]
+     (validate-event! event)
+     (http/post (topic-produce-url config)
+                {:async? true
+                 :throw-exceptions false
+                 :headers {"Content-type" "application/json"
+                           "Authorization" write-key}
+                 :body (json/generate-string event)}
+                (partial check-topic-produce-response response)
+                (partial md/error! response))
+     response)))
 
-(defn send-event-async! [{:keys [write-api-key topic-id] :as config} callback event]
-  (validate-event! event)
-  (client/post (format "%s/v1/topics/%s/produce" (base-url config) topic-id)
-               {:async? true
-                :throw-exceptions false
-                :headers {"Authorization" write-api-key
-                          "Content-type" (content-type (:format config))}
-                :body (format-payload (:format config) event)
-                :accept :json}
-               (fn [response] (callback (process-topic-response response)))
-               (fn [e] (process-exception e))))
+(defn topic-send-events!
+  "Send a batch of events to a Pyroclast topic.
+  Event must be of the form [{:value ...} {:value ...}].
+  Returns a dereffable deferred."
+  ([{:keys [pyroclast.topic/write-key pyroclast.topic/id] :as config} events]
+   (let [response (md/deferred)]
+     (run! validate-event! events)
+     (http/post (topic-bulk-produce-url config)
+                {:async? true
+                 :throw-exceptions true
+                 :headers {"Content-type" "application/json"
+                           "Authorization" write-key}
+                 :body (json/generate-string events)}
+                (comp (partial check-topic-produce-response response))
+                (partial md/error! response))
+     response)))
 
-(defn send-events-async! [{:keys [write-api-key topic-id] :as config} callback events]
-  (run! validate-event! events)
-  (client/post (format "%s/v1/topics/%s/bulk-produce" (base-url config) topic-id)
-               {:async? true
-                :throw-exceptions false
-                :headers {"Authorization" write-api-key
-                          "Content-type" (content-type (:format config))}
-                :body (format-payload (:format config) events)
-                :accept :json}
-               (fn [response] (callback (process-topic-response response)))
-               (fn [e] (process-exception e))))
+(defn- check-topic-subscribe-response
+  "Handles API and HTTP Client errors, bubbling both back up the promise chain."
+  [deferred {:keys [status body] :as response}]
+  (cond (= status 201) (md/success! deferred (json/parse-string body true))
+        (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
+        (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
+        :else (md/error! deferred (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {}))))
 
-(defn subscribe-to-topic!
-  "Creates a new consumer, joining it to the specified consumer group. Returns a
-  consumer instance map.
+(defn topic-subscribe
+  "Creates a new consumer instance, returns a consumer instance map able to
+  manipulate your Pyroclast consumer.
 
-  offset - One of `:earliest` or `:latest`
-  partitions - A list of partitions to consumer from. `:all` will consume from all partitions"
-  ([{:keys [read-api-key topic-id] :as config} consumer-group-name]
-   (subscribe-to-topic! config consumer-group-name {}))
-  ([{:keys [read-api-key topic-id] :as config} consumer-group-name {:keys [offset partitions]
-                                                                    :or {offset :earliest
-                                                                         partitions :all}}]
+  Options:
+  :auto-offset-reset - One of `:earliest` or `:latest`. Defaults to :earliest
+  :partitions - A list of partitions to consumer from. `:all` will consume from all partitions. Defaults to :all
+
+  Returns a dereffable deferred."
+  ([config consumer-group-name] (topic-subscribe config consumer-group-name {}))
+  ([{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config} consumer-group-name {:keys [auto-offset-reset partitions]
+                                                                                          :or {auto-offset-reset :earliest partitions :all}}]
    (when (not (re-matches #"[a-zA-Z0-9-_]+" consumer-group-name))
      (throw (ex-info "Consumer group name must be a non-empty string of alphanumeric characters." {})))
-   (assert (#{:earliest :latest} offset))
-   (let [response
-         (client/post (format "%s/v1/topics/%s/consumers/%s/subscribe" (base-url config) topic-id consumer-group-name)
-                      {:headers {"Authorization" read-api-key}
-                       :accept :json
-                       :content-type :json
-                       :body (generate-string {"offset" offset
-                                               "partitions" partitions})
-                       :throw-exceptions? false})
-         {:keys [status body]} response]
-     (cond (= status 201)
-           (parse-string body true)
+   (assert (#{:earliest :latest} auto-offset-reset) ":offset options must be one of :earliest or :latest")
+   (let [response (md/deferred)]
+     (http/post (topic-subscribe-url config consumer-group-name)
+                {:async? true
+                 :throw-exceptions true
+                 :headers {"Content-type" "application/json"
+                           "Authorization" read-key}
+                 :body (json/generate-string {"auto.offset.reset" auto-offset-reset "partitions" partitions})}
+                (partial check-topic-subscribe-response response)
+                (partial md/error! response))
+     response)))
 
-           (= status 401)
-           (ex-info "API key unauthorized to perform this action." {})
+(defn- check-topic-poll-response
+  "Handles API and HTTP Client errors, bubbling both back up the promise chain."
+  [deferred {:keys [status body] :as response}]
+  (cond (= status 200) (md/success! deferred (vec (json/parse-string body)))
+        (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
+        (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
+        :else (md/error! deferred (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {}))))
 
-           :else
-           (ex-info unknown-message {:response response})))))
+(defn topic-consumer-poll!
+  "Takes a Pyroclast API config and a consumer instance map as returned by
+  `topic-subscribe`. Polls topic for records. Returns a dereffable
+  deferred with zero or more records."
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
+  (assert group-id "Must supply a consumer instance map with a :group-id")
+  (assert consumer-instance-id "Must supply a consumer instance map with a :consumer-instance-id")
+  (let [response (md/deferred)]
+    (http/post (topic-poll-url config group-id consumer-instance-id)
+               {:async? true
+                :throw-exceptions true
+                :headers {"Content-type" "application/json"
+                          "Authorization" read-key}}
+               (partial check-topic-poll-response response)
+               (partial md/error! response))
+    response))
 
-(defn poll-topic!
-  "Polls a topic using a consumer instance map."
-  [{:keys [read-api-key topic-id] :as config} {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
-  (let [response
-        (client/post (format "%s/v1/topics/%s/consumers/%s/instances/%s/poll" (base-url config) topic-id group-id consumer-instance-id)
-                     {:headers {"Authorization" read-api-key}
-                      :accept :json
-                      :throw-exceptions? false})
-        {:keys [status body]} response]
-    (cond (= status 200)
-          (parse-string body true)
+(defn- check-topic-commit-response
+  "Handles API and HTTP Client errors, bubbling both back up the promise chain."
+  [deferred {:keys [status body] :as response}]
+  (cond (= status 200) (md/success! deferred true)
+        (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
+        (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
+        (= status 500) (md/error! deferred (ex-info (str "Server error: " body) {}))
+        :else (md/error! deferred (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {}))))
 
-          (= status 401)
-          (ex-info "API key unauthorized to perform this action." {})
+(defn topic-consumer-commit-offsets
+  "Commit a consumer group instance's current offset. Ensures that after this operation
+  succeeds, new subscriptions will not see records before the current offset."
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
+  (let [response (md/deferred)]
+    (http/post (topic-commit-url config group-id consumer-instance-id)
+               {:async? true
+                :headers {"Content-type" "application/json"
+                          "Authorization" read-key}
+                :throw-exceptions true
+                :as :text}
+               (partial check-topic-commit-response response)
+               (partial md/error! response))
+    ;; Probably want this to be synchronous to avoid late commits.
+    @response))
 
-          :else
-          (ex-info unknown-message {:response response}))))
+(defn- topic-consumer-seek-simple
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}
+   direction]
+  (assert (#{"beginning" "end"} direction) "seek direction must be one of :beginning or :end")
+  (let [response (md/deferred)]
+    (http/post (topic-seek-url config group-id consumer-instance-id direction)
+               {:async? true
+                :headers {"Content-type" "application/json"
+                          "Authorization" read-key}
+                :throw-exceptions true
+                :as :text}
+               (partial check-topic-commit-response response)
+               (partial md/error! response))
+    @response))
 
-(defn process-commit-read-response [{:keys [status body] :as response}]
-  (cond (= status 200)
-        {:success? true}
+(defn topic-consumer-seek-beginning
+  "Seek a consumer across all of it's assigned partitions to the last lowest
+  uncommited offset."
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
+  (topic-consumer-seek-simple config consumer-instance-map "beginning"))
 
-        (= status 401)
-        {:success? false :reason "API key unauthorized to perform this action."}
+(defn topic-consumer-seek-end
+  "Seek a consumer across all of it's assigned partitions to the last highest
+  uncommited offset."
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
+  (topic-consumer-seek-simple config consumer-instance-map "end"))
 
-        :else
-        {:success? false :reason unknown-message :response response}))
+(defn topic-consumer-seek
+  "Seek by offset or timestamp through a topic.
+  Takes a Pyroclast API config map, a consumer instance map and a
+  vector of map partition directives for seeking the consumer instance on your topic.
 
-(defn commit-read-records! [{:keys [read-api-key topic-id] :as config} {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
-  (let [response
-        (client/post (format "%s/v1/topics/%s/consumers/%s/instances/%s/commit" (base-url config) topic-id group-id consumer-instance-id)
-                     {:headers {"Authorization" read-api-key}
-                      :accept :json
-                      :throw-exceptions? false})
-        {:keys [status body]} response]
-    (cond (= status 200)
-          true
+  Each map entry in the vector specifies a partition and a seek strategy.
+  `:partition` - A string denoting the partition.
+  `:offset`    - An ordinal offset representing a specific uncommited position.
+  `:timestamp` - A temporal offset representing the earliest uncommited position.
 
-          (= status 401)
-          (ex-info "API key unauthorized to perform this action." {})
+  Examples:
+  `{:partition \"1\" :offset 12}` - seek to a specific offset.
+  `{:partition \"0\" :timestamp \"1508293577\"}` - seek to a timestamp."
+  [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+   {:keys [group-id consumer-instance-id] :as consumer-instance-map}
+   partition-directives]
+  (assert (every? :partition partition-directives) "All partition directives must contain a :partition key.")
+  (assert (every? (fn [m] (or (:offset m) (:timestamp m))) partition-directives) "All partition directives must contain either a :offset or a :timestamp key")
+  (let [response (md/deferred)]
+    (http/post (topic-seek-url config group-id consumer-instance-id)
+               {:async? true
+                :throw-exceptions true
+                :headers {"Content-type" "application/json"
+                          "Authorization" read-key}
 
-          :else
-          (ex-info unknown-message {:response response}))))
+                :body (json/generate-string partition-directives)}
+               (partial check-topic-commit-response response)
+               (partial md/error! response))
+    @response))
 
-(defn process-service-response [{:keys [status body] :as response}]
-  (cond (= status 200)
-        {:success? true
-         :aggregates (parse-string body true)}
+(defn- check-deployment-aggregates-response
+  "Handles API and HTTP Client errors, bubbling both back up the promise chain."
+  [deferred {:keys [status body] :as response}]
+  (cond (= status 200) (md/success! deferred (json/parse-string body))
+        (= status 400) (md/error! deferred (ex-info "Request was malformed." {:response response}))
+        (= status 401) (md/error! deferred (ex-info "API key unauthorized to perform this action." {}))
+        :else (md/error! deferred (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {}))))
 
-        (= status 401)
-        {:success? false :reason "API key unauthorized to perform this action."}
+(defn deployment-fetch-aggregate
+  "Return a subset of data from a specific deployment aggregate. Subset is specified
+  by a `query` map.
 
-        (= status 404)
-        {:success? false :reason "Aggregate not found"}
+  Query map can take the following keys:
 
-        :else
-        {:success? false :reason unknown-message :response response}))
+  `:start` - a positive integer representing the lower bound timestamp on aggregate data to return.
+  `:end` - a positive integer representing the upper bound timestamp on aggregate data to return.
+  `:groups` - a subset of groups to return if using a session window.
+  `:sort` - a boolean indicating if the aggregate should be sorted by timestamp."
+  [{:keys [pyroclast.deployment/read-key pyroclast.deployment/id] :as config} aggregate-name {:keys [start end groups sort] :as query}]
+  (let [response (md/deferred)
+        query (assoc query :datetime-format :iso-8601)]
+    (http/get (deployment-aggregate-url config aggregate-name)
+              {:async? true
+               :throw-exceptions true
+               :headers {"Content-type" "application/json"
+                         "Authorization" read-key}
+               :body (json/generate-string query)}
+              (partial check-deployment-aggregates-response response)
+              (partial md/error! response))
+    response))
 
-(defn read-aggregates [{:keys [read-api-key deployment-id] :as config}]
-  (let [response
-        (client/get (format "%s/v1/deployments/%s/aggregates" (base-url config) deployment-id)
-                    {:headers {"Authorization" read-api-key}
-                     :accept :json
-                     :throw-exceptions? false})]
-    (process-service-response response)))
+(defn deployment-fetch-aggregates
+  "Returns the full aggregate for a deployment.
+  Returns a dereffable deferred containing the full aggregate corresponding to
+  the deployment specified in config."
+  [{:keys [pyroclast.deployment/read-key pyroclast.deployment/id] :as config}]
+  (let [response (md/deferred)]
+    (http/get (deployment-aggregates-url config)
+              {:async? true
+               :throw-exceptions true
+               :headers {"Content-type" "application/json"
+                         "Authorization" read-key}}
+              (partial check-deployment-aggregates-response response)
+              (partial md/error! response))
+    response))
 
-(defn make-query-criteria [{:keys [start end groups datetime-format sort?]}]
-  (when groups
-    (when (not (seq groups))
-      (throw (ex-info "Groups must be a non-empty collection." {:groups groups}))))
-  (cond-> {}
-    start (assoc :start start)
-    end (assoc :end end)
-    groups (assoc :groups groups)
-    sort? (assoc :sort sort?)
-    datetime-format (assoc :datetime-format datetime-format)))
+;; Unimplemented
+#_(defn stream-topic!
+    "Takes a Pyroclast API config and a consumer instance map as returned by
+  `subscribe-to-topic`. Opens a SSE connection to the server, continously
+  calling your callback with new messages."
+    [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+     {:keys [group-id consumer-instance-id] :as consumer-instance-map}]
+    (assert group-id "Must supply a consumer instance map with a :group-id")
+    (assert consumer-instance-id "Must supply a consumer instance map with a :consumer-instance-id")
+    (let [{:keys [status body] :as response}
+          (http/get (topic-poll-url config group-id consumer-instance-id)
+                    {:throw-exceptions true
+                     :as :stream
+                     :headers {"Content-type" "text/event-stream"
+                               "Authorization" read-key}})]
+      (cond (= status 200) body
+            (= status 400) (ex-info "Request was malformed." {:response response})
+            (= status 401) (throw (ex-info "API key unauthorized to perform this action." {}))
+            :else (throw (ex-info "Unknown problem. Open an issue on this repository if you're seeing this status." {})))))
 
-(defn read-aggregate
-  ([config aggregate-name]
-   (read-aggregate config aggregate-name {}))
-  ([{:keys [read-api-key deployment-id] :as config} aggregate-name opts]
-   (let [response
-         (client/post (format "%s/v1/deployments/%s/aggregates/%s" (base-url config) deployment-id aggregate-name)
-                      {:headers {"Authorization" read-api-key}
-                       :body (generate-string (make-query-criteria opts))
-                       :accept :json
-                       :throw-exceptions? false})]
-     (process-service-response response))))
+#_(defn consumer-seek
+    "Seek by offset or timestamp through a topic.
+  Takes a Pyroclast API config map, a consumer instance map and a
+  vector of directives for seeking the consumer instance on your topic.
+
+  Each map entry in the vector specifies a partition and a seek strategy.
+  `:partition` - can be either a string denoting the partition or `:all` for all partitions
+  `:offset` - An ordinal offset representing a position on a specific or `:all` partitions
+
+  Examples:
+  `{:partition \"1\" :offset 12}` - seek to a specific offset.
+  `{:partition \"0\" :timestamp \"1508293577\"}` - seek to a timestamp.
+  `{:partition \"1\" :offset :beginning}` - seek to the beginning of the topics uncommited records.
+  `{:partition \"1\" :offset :end}` - seek to the last uncommited record in the topic.
+  `{:partition :all :offset :offset 12}` - seek all partitions to a specific offset.
+  "
+    [{:keys [pyroclast.topic/read-key pyroclast.topic/id] :as config}
+     {:keys [group-id consumer-instance-id] :as consumer-instance-map}])

--- a/src/pyroclast_clojure/v1/client.clj
+++ b/src/pyroclast_clojure/v1/client.clj
@@ -125,7 +125,8 @@
                   (if (= 201 status)
                     (md/success! prom (json/parse-string body true))
                     (common-response prom resp)))
-                (partial md/error! prom))
+                (fn [resp]
+                  (common-response promise (ex-data resp))))
      (deref prom))))
 
 (defn topic-consumer-poll!
@@ -146,7 +147,8 @@
                  (if (= 200 status)
                    (md/success! promise (vec (json/parse-string body)))
                    (common-response promise resp)))
-               (partial md/error! promise))
+               (fn [resp]
+                 (common-response promise (ex-data resp))))
     promise))
 
 (defn topic-consumer-commit-offsets
@@ -165,7 +167,8 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (partial md/error! promise))
+               (fn [resp]
+                 (common-response promise (ex-data resp))))
     ;; Probably want this to be synchronous to avoid late commits.
     @promise))
 
@@ -185,7 +188,8 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (partial md/error! promise))
+               (fn [resp]
+                 (common-response promise (ex-data resp))))
     @promise))
 
 (defn topic-consumer-seek-beginning
@@ -232,7 +236,8 @@
                  (if (= 200 status)
                    (md/success! promise true)
                    (common-response promise resp)))
-               (partial md/error! promise))
+               (fn [resp]
+                 (common-response promise (ex-data resp))))
     @promise))
 
 (defn deployment-fetch-aggregate
@@ -258,7 +263,8 @@
                 (if (= 200 status)
                   (md/success! promise (json/parse-string body))
                   (common-response promise resp)))
-              (partial md/error! promise))
+              (fn [resp]
+                (common-response promise (ex-data resp))))
     promise))
 
 (defn deployment-fetch-aggregates
@@ -276,7 +282,8 @@
                 (if (= 200 status)
                   (md/success! promise (json/parse-string body))
                   (common-response promise resp)))
-              (partial md/error! promise))
+              (fn [resp]
+                (common-response promise (ex-data resp))))
     promise))
 
 ;; Unimplemented

--- a/test/pyroclast_clojure/v1/aggregate_test.clj
+++ b/test/pyroclast_clojure/v1/aggregate_test.clj
@@ -1,0 +1,11 @@
+(ns pyroclast-clojure.v1.aggregate-test
+  (:require [pyroclast-clojure.v1.client :as client]
+            [pyroclast-clojure.util :as u]
+            [clojure.test :refer [is deftest]]))
+
+(deftest ^:topic agg-tests
+  (let [config (:aggregate-client-config (u/load-config "config.edn"))]
+    ;; Fetch aggregates for a deployment
+    (is @(client/deployment-fetch-aggregates config))))
+
+

--- a/test/pyroclast_clojure/v1/topic_test.clj
+++ b/test/pyroclast_clojure/v1/topic_test.clj
@@ -3,35 +3,35 @@
             [pyroclast-clojure.util :as u]
             [clojure.test :refer [is deftest]]))
 
-(deftest ^:topic producer-tests
-  (let [config (:client-config (u/load-config "config.edn"))]
-    (is @(client/topic-send-event! config {:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}))
-
-    (is @(client/topic-send-events! config [{:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}
-                                            {:value {:event-type "page-visit" :page "/console" :timestamp 1495072895032}}]))
-
+(deftest ^:topic topic-tests
+  (let [config (:topic-client-config (u/load-config "config.edn"))]
     (let [group "my-subscriber-group"
-          consumer-instance-map @(client/topic-subscribe config group)]
+         consumer-instance-map (client/topic-subscribe config group)]
+      (client/topic-consumer-seek-end config consumer-instance-map)
+      (is @(client/topic-send-event! config {:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}))
+      (is @(client/topic-send-events! config [{:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}
+                                              {:value {:event-type "page-visit" :page "/console" :timestamp 1495072895032}}]))
       (is (pos? (count @(client/topic-consumer-poll! config consumer-instance-map))))
       (is (client/topic-consumer-commit-offsets config consumer-instance-map))
       (is (empty? @(client/topic-consumer-poll! config consumer-instance-map))))))
 
-(deftest ^:performance producer-tests
-  (is true)
-  (time
-   (let [config (:client-config (u/load-config "config.edn"))]
-     (dotimes [r 50]
-       (run! deref (mapv (fn [i]
-                           (client/topic-send-events!
-                            config
-                            [{:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
-                             {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}]))
-                         (range 50)))))))
+;; Disable perf test for now as it messes with topic test's commit history
+; (deftest ^:performance prod-perf-tests
+;   (is true)
+;   (time
+;    (let [config (:topic-client-config (u/load-config "config.edn"))]
+;      (dotimes [r 50]
+;        (run! deref (mapv (fn [i]
+;                            (client/topic-send-events!
+;                             config
+;                             [{:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}
+;                              {:value {:event-type "page-visit" :page "store" :timestamp 1495072835000}}]))
+;                          (range 50)))))))

--- a/test/pyroclast_clojure/v1/topic_test.clj
+++ b/test/pyroclast_clojure/v1/topic_test.clj
@@ -11,6 +11,7 @@
       (is @(client/topic-send-event! config {:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}))
       (is @(client/topic-send-events! config [{:value {:event-type "page-visit" :page "/home" :timestamp 1495072835000}}
                                               {:value {:event-type "page-visit" :page "/console" :timestamp 1495072895032}}]))
+      (Thread/sleep 1000)
       (is (pos? (count @(client/topic-consumer-poll! config consumer-instance-map))))
       (is (client/topic-consumer-commit-offsets config consumer-instance-map))
       (is (empty? @(client/topic-consumer-poll! config consumer-instance-map)))

--- a/test/pyroclast_clojure/v1/topic_test.clj
+++ b/test/pyroclast_clojure/v1/topic_test.clj
@@ -1,4 +1,4 @@
-(ns pyroclast-clojure.v1.client-test
+(ns pyroclast-clojure.v1.topic-test
   (:require [pyroclast-clojure.v1.client :as client]
             [pyroclast-clojure.util :as u]
             [clojure.test :refer [is deftest]]))

--- a/test/pyroclast_clojure/v1/topic_test.clj
+++ b/test/pyroclast_clojure/v1/topic_test.clj
@@ -13,7 +13,9 @@
                                               {:value {:event-type "page-visit" :page "/console" :timestamp 1495072895032}}]))
       (is (pos? (count @(client/topic-consumer-poll! config consumer-instance-map))))
       (is (client/topic-consumer-commit-offsets config consumer-instance-map))
-      (is (empty? @(client/topic-consumer-poll! config consumer-instance-map))))))
+      (is (empty? @(client/topic-consumer-poll! config consumer-instance-map)))
+      (client/topic-consumer-seek-beginning config consumer-instance-map)
+      (is (not (empty? @(client/topic-consumer-poll! config consumer-instance-map)))))))
 
 ;; Disable perf test for now as it messes with topic test's commit history
 ; (deftest ^:performance prod-perf-tests


### PR DESCRIPTION
Rework API to be more consistent and universally include docstrings.
Support async natively using manifold to get error bubbling.
Support topic seeking, both simple and on a per-partition basis.
Support throwing errors for both server side returned values and
errors internal to the networking stack.
Unified config map usable with all client methods.
